### PR TITLE
Fix uprobe deployment failure with two similar probes

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -873,12 +873,12 @@ constexpr size_t kEventNameSizeLimit = 224;
 std::string shorten_event_name(const std::string& name) {
   constexpr size_t kRandomSuffixLen = 16;
   std::string res;
-  size_t res_hash = std::hash<std::string>{}(res);
+  size_t hash = std::hash<std::string>{}(name);
   res.reserve(kEventNameSizeLimit);
   res.assign(name);
   res.resize(kEventNameSizeLimit - kRandomSuffixLen);
   // Modulo 10^16 to keep it shorter than 16 digits. 
-  res.append(std::to_string(res_hash % 10000000000000000LU));
+  res.append(std::to_string(hash % 10000000000000000LU));
   return res;
 }
 

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -878,7 +878,7 @@ std::string shorten_event_name(const std::string& name) {
   res.assign(name);
   res.resize(kEventNameSizeLimit - kRandomSuffixLen);
   // Modulo 10^16 to keep it shorter than 16 digits. 
-  res.append(std::to_string(res % 10000000000000000LU));
+  res.append(std::to_string(res_hash % 10000000000000000LU));
   return res;
 }
 

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -873,10 +873,12 @@ constexpr size_t kEventNameSizeLimit = 224;
 std::string shorten_event_name(const std::string& name) {
   constexpr size_t kRandomSuffixLen = 16;
   std::string res;
+  size_t res_hash = std::hash<std::string>{}(res);
   res.reserve(kEventNameSizeLimit);
   res.assign(name);
   res.resize(kEventNameSizeLimit - kRandomSuffixLen);
-  res.append(random_alnum_string(kRandomSuffixLen));
+  // Modulo 10^16 to keep it shorter than 16 digits. 
+  res.append(std::to_string(res % 10000000000000000LU));
   return res;
 }
 

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -859,14 +859,15 @@ namespace {
 constexpr size_t kEventNameSizeLimit = 224;
 
 std::string shorten_event_name(const std::string& name) {
-  constexpr size_t kRandomSuffixLen = 16;
+  constexpr size_t kHashSuffixLen = 16;
   std::string res;
   size_t hash = std::hash<std::string>{}(name);
   res.reserve(kEventNameSizeLimit);
   res.assign(name);
-  res.resize(kEventNameSizeLimit - kRandomSuffixLen);
-  // Modulo 10^16 to keep it shorter than 16 digits. 
-  res.append(std::to_string(hash % 10000000000000000LU));
+  res.resize(kEventNameSizeLimit - kHashSuffixLen);
+  std::stringstream stream;
+  stream << std::hex << hash;
+  res.append(stream.str());
   return res;
 }
 

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -856,18 +856,6 @@ bool BPF::add_module(std::string module)
 
 namespace {
 
-std::string random_alnum_string(int len) {
-  static constexpr char kDict[] = "0123456789abcdefghijklmnopqrstuvwxyz";
-  static std::random_device rd;
-  std::uniform_int_distribution<size_t> dist(0, sizeof(kDict)-1);
-  std::string res;
-  res.reserve(len);
-  for (int i = 0; i < len; ++i) {
-    res.push_back(kDict[dist(rd)]);
-  }
-  return res;
-}
-
 constexpr size_t kEventNameSizeLimit = 224;
 
 std::string shorten_event_name(const std::string& name) {


### PR DESCRIPTION
When there is not enough entropy in std::random_device, it can return identical results. If two uprobes with long and very similar names get deployed together, their names, when shortened, can be exactly the same. Combined with the lack of randomness, this can cause a uprobe deployment failure.

This diff fixes this issue by using the hash of the name instead.

Test plan:
Tested with `dynamic_trace_bpf_test` on Enigma where this issue shows up.