### PR TITLE
Fix random alpha-numeric string affixed to binary path uprobe keys that are too long.

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -860,7 +860,7 @@ std::string random_alnum_string(int len) {
   static constexpr char kDict[] = "0123456789abcdefghijklmnopqrstuvwxyz";
   static std::random_device rd;
   static std::mt19937 gen(rd());
-  std::uniform_int_distribution<size_t> dist(0, sizeof(kDict)-1);
+  std::uniform_int_distribution<size_t> dist(0, sizeof(kDict)-2);
   std::string res;
   res.reserve(len);
   for (int i = 0; i < len; ++i) {

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -858,9 +858,8 @@ namespace {
 
 std::string random_alnum_string(int len) {
   static constexpr char kDict[] = "0123456789abcdefghijklmnopqrstuvwxyz";
-  static std::random_device rd;
-  static std::mt19937 gen(rd());
-  std::uniform_int_distribution<size_t> dist(0, sizeof(kDict)-2);
+  static std::mt19937 gen;
+  static std::uniform_int_distribution<size_t> dist(0, sizeof(kDict)-2);
   std::string res;
   res.reserve(len);
   for (int i = 0; i < len; ++i) {

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -859,11 +859,12 @@ namespace {
 std::string random_alnum_string(int len) {
   static constexpr char kDict[] = "0123456789abcdefghijklmnopqrstuvwxyz";
   static std::random_device rd;
+  static std::mt19937 gen(rd());
   std::uniform_int_distribution<size_t> dist(0, sizeof(kDict)-1);
   std::string res;
   res.reserve(len);
   for (int i = 0; i < len; ++i) {
-    res.push_back(kDict[dist(rd)]);
+    res.push_back(kDict[dist(gen)]);
   }
   return res;
 }

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -856,14 +856,14 @@ bool BPF::add_module(std::string module)
 
 namespace {
 
-std::string random_alnum_string(int len) {
-  static constexpr char kDict[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+std::string random_alnum_string(const int len) {
+  static constexpr std::string_view kDict = "0123456789abcdefghijklmnopqrstuvwxyz";
   static std::mt19937 gen;
-  static std::uniform_int_distribution<size_t> dist(0, sizeof(kDict)-2);
+  static std::uniform_int_distribution<size_t> dist(0, kDict.length() - 1);
   std::string res;
-  res.reserve(len);
+  res.resize(len);
   for (int i = 0; i < len; ++i) {
-    res.push_back(kDict[dist(gen)]);
+    res[i] = kDict[dist(gen)];
   }
   return res;
 }


### PR DESCRIPTION
For binary paths that form a lookup key for uprobes, we truncate and affix a random alphanumeric string, such that the key "works" in upstream code (where keys that are too long fail) and remains discoverable in the BCC wrapper by mapped lookup. This patch fixes a bug where the alphanumeric suffix was not being generated.