### PR TITLE
Revert fixes for uprobe names that are too long

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -856,14 +856,14 @@ bool BPF::add_module(std::string module)
 
 namespace {
 
-std::string random_alnum_string(const int len) {
+std::string random_alnum_string(int len) {
   static constexpr char kDict[] = "0123456789abcdefghijklmnopqrstuvwxyz";
-  static std::mt19937 gen;
-  static std::uniform_int_distribution<size_t> dist(0, sizeof(kDict) - 2);
+  static std::random_device rd;
+  std::uniform_int_distribution<size_t> dist(0, sizeof(kDict)-1);
   std::string res;
-  res.resize(len);
+  res.reserve(len);
   for (int i = 0; i < len; ++i) {
-    res[i] = kDict[dist(gen)];
+    res.push_back(kDict[dist(rd)]);
   }
   return res;
 }

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -23,7 +23,6 @@
 #include <fcntl.h>
 #include <iostream>
 #include <memory>
-#include <random>
 #include <sstream>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -854,34 +853,6 @@ bool BPF::add_module(std::string module)
     false : true;
 }
 
-namespace {
-
-std::string random_alnum_string(int len) {
-  static constexpr char kDict[] = "0123456789abcdefghijklmnopqrstuvwxyz";
-  static std::random_device rd;
-  std::uniform_int_distribution<size_t> dist(0, sizeof(kDict)-1);
-  std::string res;
-  res.reserve(len);
-  for (int i = 0; i < len; ++i) {
-    res.push_back(kDict[dist(rd)]);
-  }
-  return res;
-}
-
-constexpr size_t kEventNameSizeLimit = 224;
-
-std::string shorten_event_name(const std::string& name) {
-  constexpr size_t kRandomSuffixLen = 16;
-  std::string res;
-  res.reserve(kEventNameSizeLimit);
-  res.assign(name);
-  res.resize(kEventNameSizeLimit - kRandomSuffixLen);
-  res.append(random_alnum_string(kRandomSuffixLen));
-  return res;
-}
-
-}  // namespace
-
 std::string BPF::get_uprobe_event(const std::string& binary_path,
                                   uint64_t offset, bpf_probe_attach_type type,
                                   pid_t pid) {
@@ -890,15 +861,6 @@ std::string BPF::get_uprobe_event(const std::string& binary_path,
   res += "_0x" + uint_to_hex(offset);
   if (pid != -1)
     res += "_" + std::to_string(pid);
-  if (res.size() > kEventNameSizeLimit) {
-    auto iter = name_map_.find(res);
-    if (iter != name_map_.end()) {
-      return iter->second;
-    }
-    std::string shortend_name = shorten_event_name(res);
-    name_map_[res] = shortend_name;
-    return shortend_name;
-  }
   return res;
 }
 

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -341,9 +341,6 @@ class BPF {
   std::string all_bpf_program_;
 
   std::map<std::string, open_probe_t> kprobes_;
-  // For uprobes, if the binary path is longer than 250, we'll shorten them. And then keep the
-  // mapping.
-  std::map<std::string, std::string> name_map_;
   std::map<std::string, open_probe_t> uprobes_;
   std::map<std::string, open_probe_t> tracepoints_;
   std::map<std::string, open_probe_t> raw_tracepoints_;


### PR DESCRIPTION
93f866ae and 44d4590fba introduced a fix that, when the uprobe name is too long, truncates the original name and attaches a random string to the uprobe name, stored in a `name_map_`. 
After discussion, we decided that using the hash of the name is a better fix, which also eliminates the need for the `name_map_`.
This diff reverts the fixes using a random string and another fix using hash of the uprobe name will follow.